### PR TITLE
Fix IllegalStateException

### DIFF
--- a/src/rp/robotics/simulation/SimulatedMotor.java
+++ b/src/rp/robotics/simulation/SimulatedMotor.java
@@ -169,29 +169,31 @@ public class SimulatedMotor implements RegulatedMotor {
 		m_direction = _direction;
 		m_isMoving = true;
 
-		m_moveThread = new Thread(new Runnable() {
-			@Override
-			public void run() {
-				move(_tachoPredicate);
-
-			}
-		});
-		m_regulateThread = new Thread(new Runnable() {
-
-			@Override
-			public void run() {
-				regulate();
-
-			}
-		});
-
-		m_moveThread.setPriority(10);
-		m_regulateThread.setPriority(8);
-
-		m_moveThread.setDaemon(true);
-		m_regulateThread.setDaemon(true);
-		m_moveThread.start();
-		m_regulateThread.start();
+		synchronized (this) {
+			m_moveThread = new Thread(new Runnable() {
+				@Override
+				public void run() {
+					move(_tachoPredicate);
+	
+				}
+			});
+			m_regulateThread = new Thread(new Runnable() {
+	
+				@Override
+				public void run() {
+					regulate();
+	
+				}
+			});
+	
+			m_moveThread.setPriority(10);
+			m_regulateThread.setPriority(8);
+	
+			m_moveThread.setDaemon(true);
+			m_regulateThread.setDaemon(true);
+			m_moveThread.start();
+			m_regulateThread.start();
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Sometimes the assignment will throw an IllegalThreadStateException. This is thrown because the same thread can't be started twice. Here's what happens:

Thread 1 creates a new Thread and sets a member field to it
Thread 2 creates a new Thread and sets a member field to it
Thread 2 starts the new thread
Thread 1 resumes
Thread 1 starts the new thread, but the one created by thread 2.

```
Exception in thread "Thread-364" java.lang.IllegalThreadStateException
    at java.lang.Thread.start(Unknown Source)
    at rp.robotics.simulation.SimulatedMotor.startMove(SimulatedMotor.java:193)
    at rp.robotics.simulation.SimulatedMotor.rotateTo(SimulatedMotor.java:309)
    at rp.robotics.simulation.SimulatedMotor.rotate(SimulatedMotor.java:286)
    at lejos.robotics.navigation.DifferentialPilot.rotate(DifferentialPilot.java:433)
    at lejos.robotics.navigation.DifferentialPilot.rotate(DifferentialPilot.java:410)
    at rp.assignments.individual.ex1.SolutionPart1.run(SolutionPart1.java:40)
    at java.lang.Thread.run(Unknown Source)
```
