### PR TITLE
Add insets to frame size

### DIFF
--- a/src/rp/robotics/testing/TestViewer.java
+++ b/src/rp/robotics/testing/TestViewer.java
@@ -1,5 +1,8 @@
 package rp.robotics.testing;
 
+import java.awt.Dimension;
+import java.awt.Insets;
+
 import javax.swing.JFrame;
 
 import rp.robotics.simulation.MapBasedSimulation;
@@ -45,9 +48,10 @@ public class TestViewer {
 		frame.addWindowListener(new KillMeNow());
 
 		frame.pack();
-		frame.setSize(viz.getMinimumSize());
+		Insets insets = frame.getInsets();
+		Dimension min = viz.getMinimumSize();
+		frame.setSize((int)(min.getWidth() + insets.left), (int)(min.getHeight() + insets.top));
 		frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		frame.setVisible(true);
 	}
-
 }


### PR DESCRIPTION
Adding the insets to the frame size makes the JFrame consider the borders
and title bar of the window when sizing. Hence the visualisation window
should now be properly sized.
