### PR TITLE
Fixed shape log messages

### DIFF
--- a/src/rp/assignments/individual/ex1/Ex1Tests.java
+++ b/src/rp/assignments/individual/ex1/Ex1Tests.java
@@ -193,19 +193,19 @@ public class Ex1Tests extends AbstractTestHarness {
 
 	@Test
 	public void pentagonTest() {
-		System.out.println("Running triangle test");
+		System.out.println("Running pentagon test");
 		runSequenceTest(createPentagonTest());
 	}
 
 	@Test
 	public void octagonTest() {
-		System.out.println("Running square test");
+		System.out.println("Running octagon test");
 		runSequenceTest(createOctagonTest());
 	}
 
 	@Test
 	public void nonagonTest() {
-		System.out.println("Running decagon test");
+		System.out.println("Running nonagon test");
 		runSequenceTest(createNonagonTest());
 	}
 


### PR DESCRIPTION
It was a bit confusing when I saw "running triangle test" and then suddenly saw "pentagon test failed...". It felt like some magic was going on behind the scene to try and merge many pentagon tests to create a triangle test.